### PR TITLE
fix: resolve CI build conflict

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: Java CI with Gradle
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+
+    - name: Build with Gradle
+      # Exécute la tâche "clean" pour assurer un build propre, puis "build"
+      # Utilise "gradle" car le wrapper n'est pas inclus dans le projet
+      run: gradle clean build
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: Henebrain-Plugin
+        path: build/libs/*.jar

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,3 +30,16 @@ tasks.withType<org.gradle.api.tasks.compile.JavaCompile>().configureEach {
     options.release.set(21)
 }
 
+tasks {
+    shadowJar {
+        archiveBaseName.set(rootProject.name)
+        archiveClassifier.set("")
+
+        mergeServiceFiles()
+        exclude("META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA")
+    }
+    build {
+        dependsOn(shadowJar)
+    }
+}
+


### PR DESCRIPTION
## Summary
- configure `shadowJar` to merge service files and exclude signature metadata
- ensure `build` depends on `shadowJar`
- add GitHub Actions workflow using global `gradle clean build`

## Testing
- `gradle clean build`


------
https://chatgpt.com/codex/tasks/task_e_68a22c50a72483249e220013a14e956d