### PR TITLE
HB-5: Fix Flyway API usage and update DB doctor command

### DIFF
--- a/src/main/java/io/github/gordoxgit/henebrain/commands/DbCommand.java
+++ b/src/main/java/io/github/gordoxgit/henebrain/commands/DbCommand.java
@@ -7,6 +7,8 @@ import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.flywaydb.core.api.MigrationInfoService;
+import org.flywaydb.core.api.MigrationInfo;
 
 import java.sql.Connection;
 
@@ -60,9 +62,16 @@ public class DbCommand implements CommandExecutor {
                         + " idle=" + mx.getIdleConnections());
             }
 
-            var info = flywayManager.info();
-            var current = info.current() != null ? info.current().getVersion() : "none";
-            sender.sendMessage(ChatColor.GRAY + "Flyway version=" + current + " pending=" + info.pending().size());
+            String prefix = "[Henebrain-DB] ";
+            MigrationInfoService info = flywayManager.info();
+            MigrationInfo current = info.current();
+
+            String currentVersion = (current != null && current.getVersion() != null)
+                    ? current.getVersion().toString() : "none";
+            int pendingCount = info.pending() != null ? info.pending().length : 0;
+
+            sender.sendMessage(prefix + "Flyway current version: " + currentVersion);
+            sender.sendMessage(prefix + "Flyway pending migrations: " + pendingCount);
         } catch (Exception e) {
             sender.sendMessage(ChatColor.RED + "Database check failed: " + e.getMessage());
         }

--- a/src/main/java/io/github/gordoxgit/henebrain/database/FlywayManager.java
+++ b/src/main/java/io/github/gordoxgit/henebrain/database/FlywayManager.java
@@ -4,7 +4,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.output.MigrateResult;
-import org.flywaydb.core.api.output.InfoResult;
+import org.flywaydb.core.api.MigrationInfoService;
 
 import javax.sql.DataSource;
 
@@ -28,7 +28,8 @@ public class FlywayManager {
     public MigrateResult migrate() {
         try {
             MigrateResult result = flyway.migrate();
-            plugin.getLogger().info("Flyway migrated " + result.migrationsExecuted + " migrations.");
+            plugin.getLogger().info("Flyway a appliqué " + result.migrationsExecuted
+                    + " migration(s). Version actuelle: " + result.targetSchemaVersion);
             return result;
         } catch (FlywayException e) {
             plugin.getLogger().severe("Flyway migration failed: " + e.getMessage());
@@ -36,7 +37,7 @@ public class FlywayManager {
         }
     }
 
-    public InfoResult info() {
+    public MigrationInfoService info() {
         return flyway.info();
     }
 }


### PR DESCRIPTION
## Summary
- replace deprecated InfoResult with MigrationInfoService
- enhance migrate logging to show version
- show Flyway version and pending migrations in `/hb db doctor`

## Testing
- `mvn -B -DskipTests package` *(fails: PluginResolutionException: Could not transfer artifact... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a47c6e45ec83249d970c30f6a08aa8