### PR TITLE
Shade database dependencies and use stable Kyori platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ Dépendances Clés : PlaceholderAPI, triumph-gui
 État Actuel
 Phase 1 - Initialisation du Projet
 La structure de base du projet est en cours de création. Le pom.xml est configuré, et la documentation initiale (README, ROADMAP) est établie.
+
+## Déploiement
+
+Le JAR du plugin est auto-contenu et inclut toutes les bibliothèques nécessaires (HikariCP, Flyway, driver MySQL). Aucun ajout de dépendances externes dans le dossier `plugins` du serveur n'est requis.

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,12 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     </dependency>
 
     <dependency>
+        <groupId>net.kyori</groupId>
+        <artifactId>adventure-platform-bukkit</artifactId>
+        <version>4.3.3</version>
+    </dependency>
+
+    <dependency>
         <groupId>dev.triumphteam</groupId>
         <artifactId>triumph-gui</artifactId>
         <version>3.1.8</version>
@@ -88,25 +94,34 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
                 <target>${maven.compiler.target}</target>
             </configuration>
         </plugin>
-        <!-- Shade plugin can be configured if dependencies should be bundled -->
-        <!--
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
-            <version>3.5.0</version>
+            <version>3.5.2</version>
             <executions>
                 <execution>
+                    <id>shade</id>
                     <phase>package</phase>
                     <goals>
                         <goal>shade</goal>
                     </goals>
                     <configuration>
                         <createDependencyReducedPom>false</createDependencyReducedPom>
+                        <minimizeJar>false</minimizeJar>
+                        <artifactSet>
+                            <includes>
+                                <include>com.zaxxer:HikariCP</include>
+                                <include>org.flywaydb:flyway-core</include>
+                                <include>com.mysql:mysql-connector-j</include>
+                            </includes>
+                        </artifactSet>
+                        <transformers>
+                            <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                        </transformers>
                     </configuration>
                 </execution>
             </executions>
         </plugin>
-        -->
     </plugins>
 </build>
 </project>


### PR DESCRIPTION
## Summary
- Bundle HikariCP, Flyway, and MySQL driver with maven-shade-plugin and merge JDBC service files
- Switch Kyori Adventure platform to stable release
- Document that the produced jar is self-contained

## Testing
- `mvn -B -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a48115dd548324b4e5ed2232a62cf7