### PR TITLE
fix: add sonatype snapshot repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,10 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <id>sonatype-oss-snapshots</id>
         <url>https://oss.sonatype.org/content/repositories/snapshots</url>
     </repository>
+    <repository>
+        <id>sonatype-oss-s01-snapshots</id>
+        <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+    </repository>
 </repositories>
 
 <dependencies>


### PR DESCRIPTION
## Summary
- add Sonatype S01 snapshots repo to resolve Kyori snapshot dependency

## Testing
- `mvn -q package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a489a1433883249e405425b35b5bc0