### PR TITLE
feat: support jdbcUrl database configuration

### DIFF
--- a/src/main/java/io/github/gordoxgit/henebrain/database/HikariDataSourceProvider.java
+++ b/src/main/java/io/github/gordoxgit/henebrain/database/HikariDataSourceProvider.java
@@ -32,12 +32,20 @@ public class HikariDataSourceProvider {
         }
 
         HikariConfig config = new HikariConfig();
-        String host = dbConfig.getString("host");
-        int port = dbConfig.getInt("port");
-        String database = dbConfig.getString("database");
-        String jdbcUrl = "jdbc:mysql://" + host + ":" + port + "/" + database
-                + "?useSSL=false&serverTimezone=UTC&rewriteBatchedStatements=true";
-        config.setJdbcUrl(jdbcUrl);
+        if (dbConfig.contains("jdbcUrl")) {
+            config.setJdbcUrl(dbConfig.getString("jdbcUrl"));
+            plugin.getLogger().info("Configuration de la base de données via jdbcUrl.");
+            if (dbConfig.contains("driverClassName")) {
+                config.setDriverClassName(dbConfig.getString("driverClassName"));
+            }
+        } else {
+            plugin.getLogger().warning("jdbcUrl non trouvé dans config.yml, utilisation des anciens paramètres host/port.");
+            String host = dbConfig.getString("host", "localhost");
+            int port = dbConfig.getInt("port", 3306);
+            String database = dbConfig.getString("database");
+            String jdbcUrl = "jdbc:mysql://" + host + ":" + port + "/" + database;
+            config.setJdbcUrl(jdbcUrl);
+        }
         config.setUsername(dbConfig.getString("username"));
         config.setPassword(dbConfig.getString("password"));
 


### PR DESCRIPTION
## Summary
- allow configuring HikariCP using `jdbcUrl` and optional `driverClassName`
- keep host/port fallback with a warning if `jdbcUrl` is missing

## Testing
- `mvn clean package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-clean-plugin from https://repo.maven.apache.org/maven2: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a7c63448832495964b542a0cd3a1